### PR TITLE
fix: fix github security errors for codeql and security scanning

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   lint:
     name: Lint
@@ -134,13 +138,34 @@ jobs:
       - name: Test binary execution (Windows)
         if: runner.os == 'Windows'
         run: |
-          .\mcp-pdf-reader.exe --help
-          # Windows timeout equivalent - run for 5 seconds then kill
-          Start-Process -FilePath ".\mcp-pdf-reader.exe" -ArgumentList "-mode=server","-pdfdir=." -PassThru | ForEach-Object { Start-Sleep 5; Stop-Process $_.Id -Force }
+          # List files to debug
+          Get-ChildItem -Name "mcp-pdf-reader*"
+
+          # The Makefile creates 'mcp-pdf-reader' without .exe extension
+          # We need to rename it for Windows compatibility
+          if (Test-Path "mcp-pdf-reader") {
+            Move-Item "mcp-pdf-reader" "mcp-pdf-reader.exe"
+          }
+
+          if (Test-Path "mcp-pdf-reader.exe") {
+            .\mcp-pdf-reader.exe --help
+            # Windows timeout equivalent - run for 5 seconds then kill
+            $process = Start-Process -FilePath ".\mcp-pdf-reader.exe" -ArgumentList "-mode=server","-pdfdir=." -PassThru -WindowStyle Hidden
+            Start-Sleep 5
+            Stop-Process $process.Id -Force -ErrorAction SilentlyContinue
+          } else {
+            Write-Error "mcp-pdf-reader binary not found"
+            Get-ChildItem
+            exit 1
+          }
 
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
@@ -149,6 +174,9 @@ jobs:
         uses: actions/setup-go@v5.5.0
         with:
           go-version: "1.24"
+
+      - name: Install dependencies
+        run: go mod download
 
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
@@ -159,11 +187,12 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
+        if: always()
 
   validate:
     name: Validate
     runs-on: ubuntu-latest
-    needs: [lint, test, build]
+    needs: [lint, test, build, security]
     steps:
       - name: All checks passed
         run: echo "All validation checks passed successfully!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,6 @@ jobs:
       - name: Run tests
         run: make test
 
-      - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
-        with:
-          args: "-conf .gosec.json ./..."
-
   build:
     name: Build Release Binaries
     runs-on: ubuntu-latest


### PR DESCRIPTION
1. **Fixed SARIF Upload Permissions**
- Added `permissions` section at the workflow level with `contents: read` and `security-events: write`
- Added specific permissions to the security job for extra safety
- Added `if: always()` to the SARIF upload step so it runs even if gosec finds issues

### 2. **Fixed Windows Binary Execution**
- Updated the Windows test to handle the fact that the Makefile creates `mcp-pdf-reader` (without `.exe`)
- Added logic to rename the binary to `mcp-pdf-reader.exe` for Windows compatibility
- Added better error handling and debugging output
- Used `-WindowStyle Hidden` to prevent popup windows during testing

### 3. **Updated Dependencies**
- The validate job now properly depends on the security job
- Removed redundant security scanning from the release workflow (since PR workflow already covers it)

## Key Fixes:

1. **SARIF Upload Error**: Fixed by adding proper `security-events: write` permission
2. **Windows Binary Error**: Fixed by handling the binary naming mismatch between Makefile output and expected Windows executable name

The workflow should now run successfully without the "Resource not accessible by integration" error for SARIF uploads, and the Windows binary execution should work properly